### PR TITLE
Allow for commandPrefixes of more than one character.

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -37,7 +37,7 @@ module.exports = (config_filename) => {
 
     bot.client.addListener('message', (nick, channel, message) => {
         if (message.startsWith(bot.config.commandPrefix)) {
-            bot.commands.runCommand(nick, channel, message.substr(1));
+            bot.commands.runCommand(nick, channel, message.slice(bot.config.commandPrefix));
         }
     });
 

--- a/core/core.js
+++ b/core/core.js
@@ -37,7 +37,7 @@ module.exports = (config_filename) => {
 
     bot.client.addListener('message', (nick, channel, message) => {
         if (message.startsWith(bot.config.commandPrefix)) {
-            bot.commands.runCommand(nick, channel, message.slice(bot.config.commandPrefix));
+            bot.commands.runCommand(nick, channel, message.slice(bot.config.commandPrefix.length));
         }
     });
 


### PR DESCRIPTION
Instead of assuming that commandPrefix is one character, slice message
to the length of the commandPrefix, so it’d work even if commandPrefix
is “#!” or anything more than 1 character.
